### PR TITLE
Fixed MIN_Z updated too soon causing collisions and negative Y coordinates

### DIFF
--- a/cpp/src/boxologic/Boxologic.hpp
+++ b/cpp/src/boxologic/Boxologic.hpp
@@ -756,8 +756,7 @@ namespace boxologic
 						}
 						else
 						{
-							// UPDATE MIN_Z
-							scrap_min_z->cumx -= cbox_layout_width;
+							
 
 							// CREATE A NEW NODE BETWEEN MIN_Z AND RIGHT
 							struct Scrappad scrap =
@@ -766,6 +765,9 @@ namespace boxologic
 								scrap_min_z->cumz + cbox_layout_length
 							};
 							scrap_list.insert(next, scrap);
+
+							// UPDATE MIN_Z
+							scrap_min_z->cumx -= cbox_layout_width;
 						}
 					}
 				}

--- a/cpp/src/boxologic/Boxologic.hpp
+++ b/cpp/src/boxologic/Boxologic.hpp
@@ -524,7 +524,7 @@ namespace boxologic
 
 					// STORE CAUCLATED RESULTS
 					remain_layout_height = layer_thickness - pre_layer;
-					packed_layout_height -= layer_thickness + pre_layer;
+					packed_layout_height = packed_layout_height - layer_thickness + pre_layer;
 					remain_layout_length = lilz;
 					layer_thickness = layer_in_layer;
 


### PR DESCRIPTION
Hi, during some testing i noticed that some boxes were intersecting eachother, for example:

`<wrapperArray>
	<instance thickness="0.000000" type="wrapper" length="310.000000" name="Compensato 1" utilization="0.879506" width="270.000000" price="46872.000000" height="560.000000">
		<wrap instance="820525" layoutLength="278.920000" x="0.000000" y="0.000000" z="0.000000" layoutWidth="110.000000" orientation="2" layoutHeight="278.920000">
			<instance length="110.000000" type="product" name="820525" width="278.920000" height="278.920000" />
		</wrap>
		<wrap instance="820642" layoutLength="250.000000" x="110.000000" y="28.920000" z="0.000000" layoutWidth="120.650000" orientation="2" layoutHeight="250.000000">
			<instance length="120.650000" type="product" name="820642" width="250.000000" height="250.000000" />
		</wrap>
		<wrap instance="820642" layoutLength="250.000000" x="130.000000" y="28.920000" z="0.000000" layoutWidth="120.650000" orientation="2" layoutHeight="250.000000">
			<instance length="120.650000" type="product" name="820642" width="250.000000" height="250.000000" />
		</wrap>
		<wrap instance="820524" layoutLength="277.970000" x="0.000000" y="278.920000" z="0.000000" layoutWidth="130.000000" orientation="2" layoutHeight="277.970000">
			<instance length="130.000000" type="product" name="820524" width="277.970000" height="277.970000" />
		</wrap>
		<wrap instance="820643" layoutLength="250.000000" x="130.000000" y="278.920000" z="0.000000" layoutWidth="120.650000" orientation="2" layoutHeight="250.000000">
			<instance length="120.650000" type="product" name="820643" width="250.000000" height="250.000000" />
		</wrap>
	</instance>
</wrapperArray>`

This solves the problem in the c++ side, but the same problem seems to appear elsewhere.

The second commit fixes the problem mentioned in issue #9 (again, only in c++,)